### PR TITLE
fix(frontend): remove double /ws path from WebSocket URL construction

### DIFF
--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -17,7 +17,7 @@ export const useWebSocket = (onMessage?: (message: any) => void): UseWebSocketRe
   const connect = useCallback(async () => {
     try {
       // TODO: Get WS token if auth is required
-      let wsUrl = createWebSocketUrl('/transcription');
+      let wsUrl = createWebSocketUrl('');
       
       try {
         const config = await apiFetch('/api/config');

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -59,18 +59,17 @@ export function validatePatientId(patientId: string): boolean {
 
 // WebSocket utilities - Updated to support ws_token parameter
 export function createWebSocketUrl(path: string, wsToken?: string): string {
-  // Use environment variable for WebSocket URL, fallback to localhost for dev
-  const baseUrl = import.meta.env.VITE_WS_URL || 'ws://localhost:3001/ws';
-  // Remove trailing /ws if present to avoid double paths
-  const wsBaseUrl = baseUrl.replace(/\/ws$/, '');
-  
-  let url = `${wsBaseUrl}/ws${path}`;
-  
-  // Add ws_token parameter if provided
+  const wsBaseUrl = import.meta.env.VITE_WS_URL || 'ws://localhost:3001/ws';
+  let url = wsBaseUrl; // Nginx handles mapping in prod
+
+  // Only append path in local dev (avoid double /ws in prod)
+  if (path && !wsBaseUrl.includes('api.alie.app')) {
+    url += path;
+  }
+
   if (wsToken) {
     url += `?ws_token=${encodeURIComponent(wsToken)}`;
   }
-  
   return url;
 }
 


### PR DESCRIPTION
## ✅ Pre-Merge Checklist

- [ ] Environment variables correct in Vercel (`VITE_API_BASE_URL`, `VITE_ENABLE_AUTH`)
- [ ] CORS configured: prod domain in `ALLOWED_ORIGINS`
- [ ] API requests send `Content-Type: application/json`
- [ ] No `Authorization: Bearer null`
- [ ] `/health` endpoint returns 200 + JSON
- [ ] Core endpoints (word-for-word, smart, ambient) return valid JSON
- [ ] Dev-only features/flags disabled in prod
- [ ] Frontend builds (`pnpm build`)
- [ ] Backend starts without errors (`pnpm start`)

---

### 📌 Notes for this PR
(Describe what was fixed/added, and any special migration or env changes.)