### PR TITLE
fix(asr): set Transcribe to 48kHz to match browser capture

### DIFF
--- a/backend/src/services/transcriptionService.ts
+++ b/backend/src/services/transcriptionService.ts
@@ -59,7 +59,7 @@ export class TranscriptionService {
     const cmdInput: StartStreamTranscriptionCommandInput = {
       LanguageCode: (config.language_code || 'fr-CA') as any,   // single language per session
       MediaEncoding: 'pcm',
-      MediaSampleRateHertz: config.media_sample_rate_hz || 16000,
+      MediaSampleRateHertz: config.media_sample_rate_hz ?? 48000,
       AudioStream: audioIterable,
       ShowSpeakerLabel: config.show_speaker_labels || true,     // Mode-specific speaker attribution
       // MaxSpeakerLabels removed - not available for streaming transcription
@@ -71,6 +71,9 @@ export class TranscriptionService {
 
     // Create streaming command
     const command = new StartStreamTranscriptionCommand(cmdInput);
+    
+    // Log startup configuration
+    console.log(`[ASR] Start stream → ${cmdInput.MediaSampleRateHertz} Hz, encoding=pcm, lang=${cmdInput.LanguageCode}`);
     
     // Initialize session metadata
     this.sessionMetadata.set(sessionId, { startTime: new Date() });


### PR DESCRIPTION
## ✅ Pre-Merge Checklist

- [ ] Environment variables correct in Vercel (`VITE_API_BASE_URL`, `VITE_ENABLE_AUTH`)
- [ ] CORS configured: prod domain in `ALLOWED_ORIGINS`
- [ ] API requests send `Content-Type: application/json`
- [ ] No `Authorization: Bearer null`
- [ ] `/health` endpoint returns 200 + JSON
- [ ] Core endpoints (word-for-word, smart, ambient) return valid JSON
- [ ] Dev-only features/flags disabled in prod
- [ ] Frontend builds (`pnpm build`)
- [ ] Backend starts without errors (`pnpm start`)

---

### 📌 Notes for this PR
(Describe what was fixed/added, and any special migration or env changes.)